### PR TITLE
feat: add number expression support in beancount parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,6 +287,7 @@ dependencies = [
  "itertools",
  "latestmap",
  "log",
+ "once_cell",
  "pest",
  "pest_consume",
  "pest_derive",

--- a/extensions/beancount/Cargo.toml
+++ b/extensions/beancount/Cargo.toml
@@ -17,6 +17,7 @@ chrono = { version = "0.4", features = ["serde"] }
 bigdecimal = { version = "0.3", features = ["serde"] }
 snailquote = "0.3"
 latestmap = "0.1"
+once_cell = "1.19"
 
 [dev-dependencies]
 indoc = "1"

--- a/extensions/beancount/src/beancount.pest
+++ b/extensions/beancount/src/beancount.pest
@@ -18,9 +18,9 @@ open            =  { date ~ space+ ~ "open" ~ space+ ~ account_name ~ (space+ ~ 
 close           =  { date ~ space+ ~ "close" ~ space+ ~ account_name }
 note            =  { date ~ space+ ~ "note" ~ space+ ~ account_name ~ space+ ~ string }
 pad             =  { date ~ space+ ~ "pad" ~ space+ ~ account_name ~ space+ ~ account_name }
-balance         =  { date ~ space+ ~ "balance" ~ space+ ~ account_name ~ space+ ~ number ~ space+ ~ commodity_name }
+balance         =  { date ~ space+ ~ "balance" ~ space+ ~ account_name ~ space+ ~ number_expr ~ space+ ~ commodity_name }
 document        =  { date ~ space+ ~ "document" ~ space+ ~ account_name ~ space+ ~ string }
-price           =  { date ~ space+ ~ "price" ~ space+ ~ commodity_name ~ space+ ~ number ~ space+ ~ commodity_name }
+price           =  { date ~ space+ ~ "price" ~ space+ ~ commodity_name ~ space+ ~ number_expr ~ space+ ~ commodity_name }
 event           =  { date ~ space+ ~ "event" ~ space+ ~ string ~ space+ ~ string }
 custom          =  { date ~ space+ ~ "custom" ~ space+ ~ string ~ (space+ ~ string_or_account)+ }
 budget          =  { date ~ space+ ~ "custom" ~ space+ ~ "budget" ~ space+ ~ unquote_string ~ space+ ~ commodity_name ~ metas? }
@@ -46,15 +46,15 @@ transaction_posting   =  { transaction_flag? ~ account_name ~ (space+ ~ posting_
 transaction_next_line = _{ identation ~ transaction_line }
 
 posting_unit   = { (posting_amount)? ~ posting_meta }
-posting_amount = { number ~ space+ ~ commodity_name }
+posting_amount = { number_expr ~ space+ ~ commodity_name }
 posting_meta   = { (space+ ~ "{" ~ space* ~ posting_cost ~ price_cost_date? ~ space* ~ "}")? ~ space* ~ posting_price? }
 
-posting_cost    =  { number ~ space+ ~ commodity_name }
+posting_cost    =  { number_expr ~ space+ ~ commodity_name }
 price_cost_date = _{ space* ~ "," ~ space* ~ date }
 posting_price   =  { posting_single_price | posting_total_price }
 
-posting_single_price = { "@" ~ space+ ~ number ~ space+ ~ commodity_name }
-posting_total_price  = { "@@" ~ space+ ~ number ~ space+ ~ commodity_name }
+posting_single_price = { "@" ~ space+ ~ number_expr ~ space+ ~ commodity_name }
+posting_total_price  = { "@@" ~ space+ ~ number_expr ~ space+ ~ commodity_name }
 
 string_or_account = { account_name | string }
 
@@ -95,5 +95,15 @@ space = _{ " " | "\t" }
 line  = _{ NEWLINE }
 
 number = @{
-    "-"? ~ ("0" | ASCII_NONZERO_DIGIT ~ ASCII_DIGIT*) ~ ("." ~ ASCII_DIGIT*)? ~ (^"e" ~ ("+" | "-")? ~ ASCII_DIGIT+)?
+    ("0" | ASCII_NONZERO_DIGIT ~ ASCII_DIGIT*) ~ ("." ~ ASCII_DIGIT*)? ~ (^"e" ~ ("+" | "-")? ~ ASCII_DIGIT+)?
 }
+
+number_expr  =  { expr_atom ~ (space* ~ expr_bin_op ~ space* ~ expr_atom)* }
+expr_atom    = _{ unary_minus? ~ space* ~ expr_primary }
+expr_primary = _{ number | "(" ~ space* ~ number_expr ~ space* ~ ")" }
+expr_bin_op  = _{ add | subtract | multiply | divide }
+unary_minus  =  { "-" }
+add          =  { "+" }
+subtract     =  { "-" }
+multiply     =  { "*" }
+divide       =  { "/" }

--- a/extensions/beancount/src/parser.rs
+++ b/extensions/beancount/src/parser.rs
@@ -4,6 +4,8 @@ use std::str::FromStr;
 use bigdecimal::BigDecimal;
 use chrono::{NaiveDate, NaiveTime};
 use itertools::{Either, Itertools};
+use once_cell::sync::OnceCell;
+use pest::{iterators::Pairs, pratt_parser::PrattParser};
 use pest_consume::{match_nodes, Error, Parser};
 use snailquote::unescape;
 use zhang_ast::amount::Amount;
@@ -17,16 +19,51 @@ type Node<'i> = pest_consume::Node<'i, Rule, ()>;
 
 #[derive(Parser)]
 #[grammar = "beancount.pest"]
-pub struct BeancountParer;
+pub struct BeancountParser;
+
+fn pratt_number_parser() -> &'static PrattParser<Rule> {
+    static PARSER: OnceCell<PrattParser<Rule>> = OnceCell::new();
+    PARSER.get_or_init(|| {
+        use pest::pratt_parser::{Assoc::*, Op};
+        use Rule::*;
+        let parser = PrattParser::new()
+            .op(Op::infix(add, Left) | Op::infix(subtract, Left))
+            .op(Op::infix(multiply, Left) | Op::infix(divide, Left))
+            .op(Op::prefix(unary_minus));
+        parser
+    })
+}
+
+fn parse_number_expr(pairs: Pairs<Rule>) -> Result<BigDecimal> {
+    pratt_number_parser()
+        .map_primary(|primary| match primary.as_rule() {
+            Rule::number => Ok(BigDecimal::from_str(primary.as_str()).unwrap()),
+            Rule::number_expr => parse_number_expr(primary.into_inner()),
+            rule => unreachable!("Unexpected number expr {:?}", rule),
+        })
+        .map_infix(|lhs, op, rhs| match op.as_rule() {
+            Rule::add => Ok(lhs? + rhs?),
+            Rule::subtract => Ok(lhs? - rhs?),
+            Rule::multiply => Ok(lhs? * rhs?),
+            Rule::divide => Ok(lhs? / rhs?),
+            rule => unreachable!("Unexpected infix operation {:?}", rule),
+        })
+        .map_prefix(|op, rhs| match op.as_rule() {
+            Rule::unary_minus => Ok(-rhs?),
+            rule => unreachable!("Unexpected prefix operation {:?}", rule),
+        })
+        .parse(pairs)
+}
 
 #[pest_consume::parser]
-impl BeancountParer {
+impl BeancountParser {
     #[allow(dead_code)]
     fn EOI(_input: Node) -> Result<()> {
         Ok(())
     }
-    fn number(input: Node) -> Result<BigDecimal> {
-        Ok(BigDecimal::from_str(input.as_str()).unwrap())
+    fn number_expr(input: Node) -> Result<BigDecimal> {
+        let pairs: Pairs<'_, Rule> = input.into_pair().into_inner();
+        parse_number_expr(pairs)
     }
     fn quote_string(input: Node) -> Result<ZhangString> {
         let string = input.as_str();
@@ -165,26 +202,26 @@ impl BeancountParer {
 
     fn posting_cost(input: Node) -> Result<Amount> {
         let ret: Amount = match_nodes!(input.into_children();
-            [number(amount), commodity_name(c)] => Amount::new(amount, c),
+            [number_expr(amount), commodity_name(c)] => Amount::new(amount, c),
         );
         Ok(ret)
     }
     fn posting_total_price(input: Node) -> Result<Amount> {
         let ret: Amount = match_nodes!(input.into_children();
-            [number(amount), commodity_name(c)] => Amount::new(amount, c),
+            [number_expr(amount), commodity_name(c)] => Amount::new(amount, c),
         );
         Ok(ret)
     }
     fn posting_single_price(input: Node) -> Result<Amount> {
         let ret: Amount = match_nodes!(input.into_children();
-            [number(amount), commodity_name(c)] => Amount::new(amount, c),
+            [number_expr(amount), commodity_name(c)] => Amount::new(amount, c),
         );
         Ok(ret)
     }
 
     fn posting_amount(input: Node) -> Result<Amount> {
         let ret: Amount = match_nodes!(input.into_children();
-            [number(amount), commodity_name(c)] => Amount::new(amount, c),
+            [number_expr(amount), commodity_name(c)] => Amount::new(amount, c),
         );
         Ok(ret)
     }
@@ -406,7 +443,7 @@ impl BeancountParer {
 
     fn balance(input: Node) -> Result<BeancountOnlyDirective> {
         let (date, account, amount, commodity): (Date, Account, BigDecimal, String) = match_nodes!(input.into_children();
-            [date(date), account_name(name), number(amount), commodity_name(commodity)] => (date, name, amount, commodity),
+            [date(date), account_name(name), number_expr(amount), commodity_name(commodity)] => (date, name, amount, commodity),
         );
         Ok(BeancountOnlyDirective::Balance(BalanceDirective {
             date,
@@ -443,7 +480,7 @@ impl BeancountParer {
 
     fn price(input: Node) -> Result<Directive> {
         let ret: (Date, String, BigDecimal, String) = match_nodes!(input.into_children();
-            [date(date), commodity_name(source), number(price), commodity_name(target)] => (date, source, price, target)
+            [date(date), commodity_name(source), number_expr(price), commodity_name(target)] => (date, source, price, target)
         );
         Ok(Directive::Price(Price {
             date: ret.0,
@@ -609,17 +646,17 @@ impl BeancountParer {
 
 pub fn parse(input_str: &str, file: impl Into<Option<PathBuf>>) -> Result<Vec<Spanned<BeancountDirective>>> {
     let file = file.into();
-    let inputs = BeancountParer::parse(Rule::entry, input_str)?;
+    let inputs = BeancountParser::parse(Rule::entry, input_str)?;
     let input = inputs.single()?;
-    BeancountParer::entry(input).map(|mut directives| {
+    BeancountParser::entry(input).map(|mut directives| {
         directives.iter_mut().for_each(|directive| directive.span.filename = file.clone());
         directives
     })
 }
 pub fn parse_time(input_str: &str) -> Result<NaiveTime> {
-    let inputs = BeancountParer::parse(Rule::time, input_str)?;
+    let inputs = BeancountParser::parse(Rule::time, input_str)?;
     let input = inputs.single()?;
-    BeancountParer::time(input)
+    BeancountParser::time(input)
 }
 
 #[cfg(test)]
@@ -688,6 +725,7 @@ mod test {
     }
     mod txn {
         use crate::parser::parse;
+        use bigdecimal::BigDecimal;
         use indoc::indoc;
         use zhang_ast::Directive;
 
@@ -695,7 +733,7 @@ mod test {
         fn should_parse_posting_meta() {
             let directive = parse(
                 indoc! {r#"
-                            1970-01-01 "Payee" "Norration"
+                            1970-01-01 "Payee" "Narration"
                               Assets:Bank
                                 a: b
                         "#},
@@ -717,7 +755,7 @@ mod test {
         fn should_parse_with_comment() {
             let directive = parse(
                 indoc! {r#"
-                            1970-01-01 "Payee" "Norration" ; 123123
+                            1970-01-01 "Payee" "Narration" ; 123123
                               Assets:Bank
                                 a: b
                               Assets:Bank ;123213
@@ -736,6 +774,28 @@ mod test {
             if let Directive::Transaction(inner) = directive {
                 assert_eq!(inner.postings.first().unwrap().meta.get_one("a").cloned().unwrap().to_plain_string(), "b");
                 assert_eq!(inner.postings.get(1).unwrap().comment.as_ref().unwrap(), "123213");
+            }
+        }
+
+        #[test]
+        fn should_support_arithmetic_expression_in_amount() {
+            use indoc::indoc;
+            let directive = parse(
+                indoc! {r#"
+                            1970-01-01 "Payee" "Narration"
+                              Assets:Bank -(120/10) + 1000 * (25--2) CNY
+                        "#},
+                None,
+            )
+            .unwrap()
+            .pop()
+            .unwrap()
+            .data
+            .left()
+            .unwrap();
+            assert!(matches!(directive, Directive::Transaction(..)));
+            if let Directive::Transaction(inner) = directive {
+                assert_eq!(inner.postings.first().unwrap().to_owned().units.unwrap().number, BigDecimal::from(26988));
             }
         }
     }


### PR DESCRIPTION
Beancount supports simple arithmetic expressions at almost every place where number literal can be used. See [1] for detailed syntax.

This commit adds similar support for zhang's beancount parser. However for simplicity these expressions are calculated when parsing, thus not kept in AST and cannot be exported again. A simple test is also added.

Some minor typo fixes are included.

[1]: https://github.com/beancount/beancount/blob/d2d1e536c82281933b7bfc9cf3137f3698dcf4dc/beancount/cparser/parser.yxx#L830-L886