### PR TITLE
feat: handle ctrl+c

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3166,6 +3166,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3419,6 +3428,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ base64 = "0.22"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "1"
-tokio = { version = "1", features = ['macros', "tracing", "rt-multi-thread"] }
+tokio = { version = "1", features = ['macros', "tracing", "signal", "rt-multi-thread"] }
 tokio-util = { version = "0.7", features = ["io", "compat"] }
 log = "0.4"
 itertools = "0.12"

--- a/zhang-cli/src/main.rs
+++ b/zhang-cli/src/main.rs
@@ -182,7 +182,15 @@ async fn main() {
         .parse_env(env)
         .init();
     let opts = Opts::parse();
-    opts.run().await;
+
+    tokio::select! {
+        _ = tokio::signal::ctrl_c() => {
+            info!("receive ctrl+c, exit");
+        }
+        _ = opts.run() => {
+            println!("operation completed");
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
with the pr, we can use ctrl+c to exit the docker image, the log shows 
```
[2024-04-26T11:54:57Z INFO  zhang_server] version: 0.1.0, build date: 2024-04-26
[2024-04-26T11:54:57Z WARN  zhang_core::options] cannot get timezone, fall back to use GMT+8 as default timezone: No such file or directory (os error 2)
[2024-04-26T11:54:57Z INFO  zhang_core::ledger] Ledger loaded
[2024-04-26T11:54:57Z INFO  zhang_server] start reload listener
[2024-04-26T11:54:57Z INFO  zhang_server] start fs event listener
[2024-04-26T11:54:57Z INFO  zhang_server] start version report tasker
[2024-04-26T11:54:57Z INFO  zhang_server] zhang is listening on http://0.0.0.0:8000/
[2024-04-26T11:54:57Z INFO  zhang_server] watching /data
[2024-04-26T11:54:57Z INFO  zhang_server] start zhang's version report task, random uuid 67e55044-10b1-426f-9247-bb680e5fe0c8 is generated
^C[2024-04-26T11:54:58Z INFO  zhang] receive ctrl+c, exit

```