### PR TITLE
add `.beancount` file extension support

### DIFF
--- a/docs/src/content/docs/installation/2-beancount_launch.md
+++ b/docs/src/content/docs/installation/2-beancount_launch.md
@@ -4,7 +4,7 @@ description: This is a page in my Starlight-powered site
 ---
 
 
-zhang 自带了 beancount 的处理器，也会在**主文件** `endpoint` 的文件后缀为 `.bc` 或 `.bean` 时，以 **beancount 处理器**启动
+zhang 自带了 beancount 的处理器，也会在**主文件** `endpoint` 的文件后缀为 `.bc`, `.bean` 或 `.beancount` 时，以 **beancount 处理器**启动
 zhang 服务端。
 
 因此你需要在启动时指定 endpoint 为 beancount 主文件。

--- a/zhang-cli/src/opendal.rs
+++ b/zhang-cli/src/opendal.rs
@@ -186,7 +186,7 @@ impl OpendalDataSource {
             .to_string()
             .as_str()
         {
-            "bc" | "bean" => true,
+            "bc" | "bean" | "beancount" => true,
             "zhang" => false,
             _ => unreachable!("not supported data format"),
         };


### PR DESCRIPTION
`.beancount` is also widely used, including in the official repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the `.beancount` file extension, enhancing file compatibility for the beancount processor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->