### PR TITLE
refact(binding/wasm): replace wee_alloc with talc

### DIFF
--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -69,7 +69,7 @@ jobs:
         run: mkdir -p build
         working-directory: ./frontend
       - name: Run test
-        run: cargo test --workspace --exclude zhang-wasm --features ${{matrix.features}}
+        run: cargo test --workspace --features ${{matrix.features}}
   wasm-test:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -69,7 +69,7 @@ jobs:
         run: mkdir -p build
         working-directory: ./frontend
       - name: Run test
-        run: cargo test --workspace --features ${{matrix.features}}
+        run: cargo test --features ${{matrix.features}}
   wasm-test:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -69,7 +69,7 @@ jobs:
         run: mkdir -p build
         working-directory: ./frontend
       - name: Run test
-        run: cargo test --features ${{matrix.features}}
+        run: cargo test --workspace --exclude zhang-wasm --features ${{matrix.features}}
   wasm-test:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -264,7 +264,7 @@ checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
 dependencies = [
  "addr2line",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
@@ -477,12 +477,6 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-
-[[package]]
-name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -590,7 +584,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "wasm-bindgen",
 ]
 
@@ -616,7 +610,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eeaa953eaad386a53111e47172c2fedba671e5684c8dd601a5f474f4f118710f"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -743,7 +737,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -815,7 +809,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "339ee130d97a610ea5a5872d2bbb130fdf68884ff09d3028b81bec8a1ac23bbc"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "dirs-sys-next",
 ]
 
@@ -868,7 +862,7 @@ version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1002,7 +996,7 @@ version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e5768da2206272c81ef0b5e951a41862938a6070da63bcea197899942d3b947"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "rustix",
  "windows-sys 0.52.0",
 ]
@@ -1013,7 +1007,7 @@ version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "redox_syscall",
  "windows-sys 0.52.0",
@@ -1212,7 +1206,7 @@ version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06fddc2749e0528d2813f95e050e87e52c8cbbae56223b9babf73b3e53b0cc6"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "js-sys",
  "libc",
  "wasi",
@@ -1582,7 +1576,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1831,7 +1825,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "digest",
 ]
 
@@ -1858,12 +1852,6 @@ checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
-
-[[package]]
-name = "memory_units"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 
 [[package]]
 name = "mime"
@@ -2090,7 +2078,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
 dependencies = [
  "bitflags 2.5.0",
- "cfg-if 1.0.0",
+ "cfg-if",
  "foreign-types",
  "libc",
  "once_cell",
@@ -2159,7 +2147,7 @@ version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
@@ -2409,7 +2397,7 @@ version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e681a6cfdc4adcc93b4d3cf993749a4552018ee0a9b65fc0ccfad74352c72a38"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "indoc 1.0.9",
  "libc",
  "memoffset",
@@ -2708,7 +2696,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "getrandom",
  "libc",
  "spin",
@@ -3082,7 +3070,7 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest",
 ]
@@ -3297,6 +3285,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "talc"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04be12ec299aadd63a0bf781d893e4b6139d33cdca6dcd6f6be31f849cedcac8"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3308,7 +3305,7 @@ version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "fastrand 2.0.2",
  "rustix",
  "windows-sys 0.52.0",
@@ -3340,7 +3337,7 @@ version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "once_cell",
 ]
 
@@ -3808,7 +3805,7 @@ version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "serde",
  "serde_json",
  "wasm-bindgen-macro",
@@ -3835,7 +3832,7 @@ version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -3967,7 +3964,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "bumpalo",
- "cfg-if 1.0.0",
+ "cfg-if",
  "encoding_rs",
  "fxprof-processed-profile",
  "indexmap 2.2.6",
@@ -4002,7 +3999,7 @@ version = "17.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3ed1bdfec9cca409d6562fe51abc75440c85fde2dc4c5b5ad65bc0405f31475"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -4053,7 +4050,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1f2e04e2a08c1f73fc36a8a6d0da38fbe3ff396e42c47826435239a26bf187a"
 dependencies = [
  "anyhow",
- "cfg-if 1.0.0",
+ "cfg-if",
  "cranelift-codegen",
  "cranelift-control",
  "cranelift-entity",
@@ -4118,7 +4115,7 @@ checksum = "e19865170650ca6cdb3b1924e42e628d29d03a1766e6de71f57d879b108ee46a"
 dependencies = [
  "anyhow",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "rustix",
  "wasmtime-asm-macros",
  "wasmtime-versioned-export-macros",
@@ -4134,7 +4131,7 @@ dependencies = [
  "addr2line",
  "anyhow",
  "bincode",
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpp_demangle",
  "gimli",
  "ittapi",
@@ -4170,7 +4167,7 @@ version = "17.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6d01b771888f8cc32fc491247095715c6971d70903f9a82803d707836998815"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -4183,7 +4180,7 @@ checksum = "b1f0f306436812a253a934444bd25230eaf33a007218a6fe92f67d3646f8dd19"
 dependencies = [
  "anyhow",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "encoding_rs",
  "indexmap 2.2.6",
  "libc",
@@ -4347,18 +4344,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
 dependencies = [
  "rustls-pki-types",
-]
-
-[[package]]
-name = "wee_alloc"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb3b5a6b2bb17cb6ad44a2e68a43e8d2722c997da10e928665c72ec6c0a0b8e"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "memory_units",
- "winapi",
 ]
 
 [[package]]
@@ -4615,7 +4600,7 @@ version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "windows-sys 0.48.0",
 ]
 
@@ -4625,7 +4610,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "windows-sys 0.48.0",
 ]
 
@@ -4829,9 +4814,9 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
+ "talc",
  "wasm-bindgen",
  "wasm-bindgen-test",
- "wee_alloc",
  "zhang-ast",
  "zhang-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,14 @@ members = [
     "bindings/python",
     "bindings/wasm",
 ]
+default-members = [
+    "zhang-core",
+    "zhang-ast",
+    "zhang-server",
+    "zhang-cli",
+    "extensions/*",
+    "bindings/python",
+]
 
 [workspace.dependencies]
 base64 = "0.22"

--- a/bindings/wasm/.travis.yml
+++ b/bindings/wasm/.travis.yml
@@ -6,64 +6,62 @@ cache: cargo
 matrix:
   include:
 
-  # Builds with wasm-pack.
-  - rust: beta
-    env: RUST_BACKTRACE=1
-    addons:
-      firefox: latest
-      chrome: stable
-    before_script:
-      - (test -x $HOME/.cargo/bin/cargo-install-update || cargo install cargo-update)
-      - (test -x $HOME/.cargo/bin/cargo-generate || cargo install --vers "^0.2" cargo-generate)
-      - cargo install-update -a
-      - curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh -s -- -f
-    script:
-      - cargo generate --git . --name testing
-      # Having a broken Cargo.toml (in that it has curlies in fields) anywhere
-      # in any of our parent dirs is problematic.
-      - mv Cargo.toml Cargo.toml.tmpl
-      - cd testing
-      - wasm-pack build
-      - wasm-pack test --chrome --firefox --headless
+    # Builds with wasm-pack.
+    - rust: beta
+      env: RUST_BACKTRACE=1
+      addons:
+        firefox: latest
+        chrome: stable
+      before_script:
+        - (test -x $HOME/.cargo/bin/cargo-install-update || cargo install cargo-update)
+        - (test -x $HOME/.cargo/bin/cargo-generate || cargo install --vers "^0.2" cargo-generate)
+        - cargo install-update -a
+        - curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh -s -- -f
+      script:
+        - cargo generate --git . --name testing
+        # Having a broken Cargo.toml (in that it has curlies in fields) anywhere
+        # in any of our parent dirs is problematic.
+        - mv Cargo.toml Cargo.toml.tmpl
+        - cd testing
+        - wasm-pack build
+        - wasm-pack test --chrome --firefox --headless
 
-  # Builds on nightly.
-  - rust: nightly
-    env: RUST_BACKTRACE=1
-    before_script:
-      - (test -x $HOME/.cargo/bin/cargo-install-update || cargo install cargo-update)
-      - (test -x $HOME/.cargo/bin/cargo-generate || cargo install --vers "^0.2" cargo-generate)
-      - cargo install-update -a
-      - rustup target add wasm32-unknown-unknown
-    script:
-      - cargo generate --git . --name testing
-      - mv Cargo.toml Cargo.toml.tmpl
-      - cd testing
-      - cargo check
-      - cargo check --target wasm32-unknown-unknown
-      - cargo check                                 --no-default-features
-      - cargo check --target wasm32-unknown-unknown --no-default-features
-      - cargo check                                 --no-default-features --features console_error_panic_hook
-      - cargo check --target wasm32-unknown-unknown --no-default-features --features console_error_panic_hook
-      - cargo check                                 --no-default-features --features "console_error_panic_hook wee_alloc"
-      - cargo check --target wasm32-unknown-unknown --no-default-features --features "console_error_panic_hook wee_alloc"
+    # Builds on nightly.
+    - rust: nightly
+      env: RUST_BACKTRACE=1
+      before_script:
+        - (test -x $HOME/.cargo/bin/cargo-install-update || cargo install cargo-update)
+        - (test -x $HOME/.cargo/bin/cargo-generate || cargo install --vers "^0.2" cargo-generate)
+        - cargo install-update -a
+        - rustup target add wasm32-unknown-unknown
+      script:
+        - cargo generate --git . --name testing
+        - mv Cargo.toml Cargo.toml.tmpl
+        - cd testing
+        - cargo check
+        - cargo check --target wasm32-unknown-unknown
+        - cargo check                                 --no-default-features
+        - cargo check --target wasm32-unknown-unknown --no-default-features
+        - cargo check                                 --no-default-features --features console_error_panic_hook
+        - cargo check --target wasm32-unknown-unknown --no-default-features --features console_error_panic_hook
 
-  # Builds on beta.
-  - rust: beta
-    env: RUST_BACKTRACE=1
-    before_script:
-      - (test -x $HOME/.cargo/bin/cargo-install-update || cargo install cargo-update)
-      - (test -x $HOME/.cargo/bin/cargo-generate || cargo install --vers "^0.2" cargo-generate)
-      - cargo install-update -a
-      - rustup target add wasm32-unknown-unknown
-    script:
-      - cargo generate --git . --name testing
-      - mv Cargo.toml Cargo.toml.tmpl
-      - cd testing
-      - cargo check
-      - cargo check --target wasm32-unknown-unknown
-      - cargo check                                 --no-default-features
-      - cargo check --target wasm32-unknown-unknown --no-default-features
-      - cargo check                                 --no-default-features --features console_error_panic_hook
-      - cargo check --target wasm32-unknown-unknown --no-default-features --features console_error_panic_hook
-      # Note: no enabling the `wee_alloc` feature here because it requires
-      # nightly for now.
+    # Builds on beta.
+    - rust: beta
+      env: RUST_BACKTRACE=1
+      before_script:
+        - (test -x $HOME/.cargo/bin/cargo-install-update || cargo install cargo-update)
+        - (test -x $HOME/.cargo/bin/cargo-generate || cargo install --vers "^0.2" cargo-generate)
+        - cargo install-update -a
+        - rustup target add wasm32-unknown-unknown
+      script:
+        - cargo generate --git . --name testing
+        - mv Cargo.toml Cargo.toml.tmpl
+        - cd testing
+        - cargo check
+        - cargo check --target wasm32-unknown-unknown
+        - cargo check                                 --no-default-features
+        - cargo check --target wasm32-unknown-unknown --no-default-features
+        - cargo check                                 --no-default-features --features console_error_panic_hook
+        - cargo check --target wasm32-unknown-unknown --no-default-features --features console_error_panic_hook
+        # Note: no enabling the `wee_alloc` feature here because it requires
+        # nightly for now.

--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -19,18 +19,14 @@ wasm-bindgen = { version = "0.2.91", features = ["serde-serialize"] }
 # code size when deploying.
 console_error_panic_hook = { version = "0.1.6", optional = true }
 
-# `wee_alloc` is a tiny allocator for wasm that is only ~1K in code size
-# compared to the default allocator's ~10K. It is slower than the default
-# allocator, however.
-#
-# Unfortunately, `wee_alloc` requires nightly Rust when targeting wasm for now.
-wee_alloc = { version = "0.4.5", optional = true }
+talc = { version = "4.4", default-features = false, features = ["lock_api", "counters"] }
 zhang-core = { path = "../../zhang-core", features = ["wasm"] }
 zhang-ast = { path = "../../zhang-ast" }
 beancount = { path = "../../extensions/beancount" }
 serde_json = { workspace = true }
 serde = { workspace = true }
 serde-wasm-bindgen = "0.6"
+
 [dev-dependencies]
 wasm-bindgen-test = "0.3.13"
 

--- a/bindings/wasm/README.md
+++ b/bindings/wasm/README.md
@@ -2,7 +2,8 @@
 
   <h1><code>wasm-pack-template</code></h1>
 
-  <strong>A template for kick starting a Rust and WebAssembly project using <a href="https://github.com/rustwasm/wasm-pack">wasm-pack</a>.</strong>
+<strong>A template for kick starting a Rust and WebAssembly project
+using <a href="https://github.com/rustwasm/wasm-pack">wasm-pack</a>.</strong>
 
   <p>
     <a href="https://travis-ci.org/rustwasm/wasm-pack-template"><img src="https://img.shields.io/travis/rustwasm/wasm-pack-template.svg?style=flat-square" alt="Build Status" /></a>
@@ -14,7 +15,7 @@
     <a href="https://discordapp.com/channels/442252698964721669/443151097398296587">Chat</a>
   </h3>
 
-  <sub>Built with 🦀🕸 by <a href="https://rustwasm.github.io/">The Rust and WebAssembly Working Group</a></sub>
+<sub>Built with 🦀🕸 by <a href="https://rustwasm.github.io/">The Rust and WebAssembly Working Group</a></sub>
 </div>
 
 ## About
@@ -28,6 +29,7 @@ Be sure to check out [other `wasm-pack` tutorials online][tutorials] for other
 templates and usages of `wasm-pack`.
 
 [tutorials]: https://rustwasm.github.io/docs/wasm-pack/tutorials/index.html
+
 [template-docs]: https://rustwasm.github.io/docs/wasm-pack/tutorials/npm-browser-packages/index.html
 
 ## 🚴 Usage
@@ -65,5 +67,3 @@ wasm-pack publish
   between WebAssembly and JavaScript.
 * [`console_error_panic_hook`](https://github.com/rustwasm/console_error_panic_hook)
   for logging panic messages to the developer console.
-* [`wee_alloc`](https://github.com/rustwasm/wee_alloc), an allocator optimized
-  for small code size.

--- a/bindings/wasm/src/lib.rs
+++ b/bindings/wasm/src/lib.rs
@@ -13,11 +13,8 @@ mod data_source;
 mod utils;
 
 // use console_error_panic_hook::hook;
-// When the `wee_alloc` feature is enabled, use `wee_alloc` as the global
-// allocator.
-#[cfg(feature = "wee_alloc")]
 #[global_allocator]
-static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
+static ALLOCATOR: talc::TalckWasm = unsafe { talc::TalckWasm::new_global() };
 
 #[wasm_bindgen(getter_with_clone)]
 pub struct PlayGroundParse {


### PR DESCRIPTION
regarding of the introduction in https://github.com/zhang-accounting/zhang/security/dependabot/46, we need to replace wee_alloc, cauze it's unmaintained. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a streamlined workspace configuration for enhanced command execution in the application.
	- Added `talc` library for improved memory allocation and performance in the WebAssembly module.

- **Bug Fixes**
	- Removed the deprecated `wee_alloc` dependency to avoid potential compatibility issues.

- **Documentation**
	- Minor formatting improvements made to the README for better readability.

- **Chores**
	- Refactored `.travis.yml` for improved clarity without changing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->